### PR TITLE
Changes type of node "robot_state_publisher" from "state_publisher" to "robot_state_publisher"

### DIFF
--- a/launch/hsrb_display.launch
+++ b/launch/hsrb_display.launch
@@ -36,7 +36,7 @@ POSSIBILITY OF SUCH DAMAGE.
     <!-- load robot -->
     <param name="robot_description" command="$(find xacro)/xacro '$(find hsrb_description)/robots/$(arg robot).urdf.xacro'" />
     <node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
-    <node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
+    <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" />
 
     <!-- load displays -->
     <param name="use_gui" value="$(arg gui)"/>


### PR DESCRIPTION
`hsrb_display.launch` throws the error:
```
ERROR: cannot launch node of type [robot_state_publisher/state_publisher]: Cannot locate node of type [state_publisher] in package [robot_state_publisher]. Make sure file exists in package path and permission is set to executable (chmod +x)
```

The cause, as described at [Cannot locate node of type [state_publisher]](https://answers.ros.org/question/357672/cannot-locate-node-of-type-state_publisher/), is this line in that launch file:
```
<node name="robot_state_publisher" pkg="robot_state_publisher" type="state_publisher" />
```


This PR updates the deprecated `type="state_publisher"` to `type="robot_state_publisher"`.